### PR TITLE
add support for CentOS7

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This module is tested on the following platforms:
 
 * CentOS 5
 * CentOS 6
+* CentOS 7
 * Ubuntu 10.04.4
 * Ubuntu 12.04.2
 * Ubuntu 13.10

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -50,7 +50,7 @@
 #
 define jenkins_job_builder::job (
   $config = {},
-  $delay = 0,
+  $delay = 5,
   $service_name = 'jenkins',
   $job_yaml = '',
 ) {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -60,6 +60,7 @@ define jenkins_job_builder::job (
   } else {
     $content = $job_yaml
   }
+
   file { "/tmp/jenkins-${name}.yaml":
     ensure  => present,
     content => $content,
@@ -67,8 +68,10 @@ define jenkins_job_builder::job (
   }
 
   exec { "manage jenkins job - ${name}":
-    command     => "/bin/sleep ${delay} && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-${name}.yaml",
+    command     => "/bin/sleep ${delay} && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-${name}.yaml",
+    path        => ['/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin'],
     refreshonly => true,
+    logoutput   => true,
     require     => Service[$service_name]
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,17 +18,22 @@ class jenkins_job_builder::params {
   $service = 'jenkins'
 
   case $::osfamily {
+
     'RedHat', 'Amazon': {
-      $python_packages = [ 'python', 'python-devel', 'python-pip', 'python-argparse']
+      if '7' == $operatingsystemmajrelease {
+        $python_packages =  [ 'python', 'python-devel', 'python-pip' ]
+      } else {
+        $python_packages = [ 'python', 'python-dev', 'python-pip', 'python-argparse' ]
+      }
     }
-    debian: {
+
+    'Debian': {
       $python_packages = [ 'python', 'python-dev', 'python-pip' ]
     }
+
     default: {
       fail("${::operatingsystem} not supported")
     }
   }
-
-
 
 }

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-7.0-x64:
+    roles:
+      - master
+    platform: el-7.0-x86_64
+    box : centos-7.0-x64-vbox436-nocm
+    box_url : https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm/versions/1.0.0/providers/virtualbox.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -13,8 +13,28 @@ describe 'jenkins_job_builder' do
 
         it { should contain_class('jenkins_job_builder::params') }
 
-        ['python', 'python-pip', 'pyyaml', 'python-argparse'].each do |dep|
+        ['python', 'python-pip', 'pyyaml'].each do |dep|
           it { should contain_package(dep).with_ensure('present') }
+        end
+
+        
+        ['python', 'python-pip', 'pyyaml'].each do |dep|
+          it { should contain_package(dep).with_ensure('present') }
+        end
+
+        if 'RedHat' == osfamily
+          let(:facts) {{ :operatingsystemmajrelease => '7', :osfamily => 'RedHat' }}
+          it { should_not contain_package('python-argparse') }
+        end
+
+        if 'Debian' == osfamily 
+          let(:facts) {{ :osfamily => 'Debian' }}
+          it { should_not contain_package('python-argparse') }
+        end
+
+        if 'Redhat' == osfamily
+          lets(:facts) {{ :operatingsystemmajrelease => '6', osfmaily => 'RedHat' }}
+          it { should contain_package(python-argparse) }
         end
 
         it { should contain_class('jenkins_job_builder::install').that_comes_before('jenkins_job_builder::config') }

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -11,7 +11,7 @@ describe 'jenkins_job_builder::job', :type => :define do
         it { should contain_file('/tmp/jenkins-test.yaml').with_content('') }
 
         it { should contain_exec('manage jenkins job - test').with(
-          'command' => '/bin/sleep 0 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
+          'command' => '/bin/sleep 0 && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
           'refreshonly' => 'true',
           'require' => 'Service[jenkins]'
         )}
@@ -27,7 +27,7 @@ describe 'jenkins_job_builder::job', :type => :define do
       }}
 
       it { should contain_exec('manage jenkins job - test').with(
-        'command' => '/bin/sleep 5 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml'
+        'command' => '/bin/sleep 5 && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml'
       )}
     end
 


### PR DESCRIPTION
Add what I think to be the necessary code for CentOS7 support. A quick pass at adding a few spec tests and a node file for acceptance testing as the beaker/serverspec code develops. As to testing code, basically just adjustments to package names for CentOS7.