### PR TITLE
PyYAML Install Failure

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,7 +16,7 @@ class jenkins_job_builder::install(
   }
 
   ensure_resource('package', $jenkins_job_builder::params::python_packages, { 'ensure' => 'present' })
-  ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => $jenkins_job_builder::params::python_packages })
+  ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => Package[$jenkins_job_builder::params::python_packages] })
 
   package { 'jenkins-job-builder':
     ensure   => $version,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,7 +16,7 @@ class jenkins_job_builder::install(
   }
 
   ensure_resource('package', $jenkins_job_builder::params::python_packages, { 'ensure' => 'present' })
-  ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => 'Package[python]'})
+  ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => $jenkins_job_builder::params::python_packages })
 
   package { 'jenkins-job-builder':
     ensure   => $version,


### PR DESCRIPTION
The PyYAML install was failing on Ubuntu 14.04 due to the incorrect title of `Package['python']` in the require reference. I have replaced this with a package title reference of the parameter instead which is working in our tests.

Thanks.