### PR TITLE
Fixes spec tests: move package tests into osfamily specific tests

### DIFF
--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -9,13 +9,9 @@ describe 'jenkins_job_builder' do
           :osfamily => osfamily,
         }}
 
-        #it { should compile.with_all_deps }
+        it { should compile.with_all_deps }
 
         it { should contain_class('jenkins_job_builder::params') }
-
-        ['python', 'python-pip', 'pyyaml', 'python-argparse'].each do |dep|
-          it { should contain_package(dep).with_ensure('present') }
-        end
 
         it { should contain_class('jenkins_job_builder::install').that_comes_before('jenkins_job_builder::config') }
         it { should contain_class('jenkins_job_builder::config') }
@@ -61,6 +57,28 @@ describe 'jenkins_job_builder' do
           'require' => 'File[/etc/jenkins_jobs/jenkins_jobs.ini]'
         )}
       end
+    end
+    describe "jenkins_job_builder class without any parameters on a 'Debian' OS" do
+      let(:params) {{ }}
+      let(:facts) {{
+        :osfamily => 'Debian',
+      }}
+
+      ['python', 'python-pip', 'pyyaml'].each do |dep|
+        it { should contain_package(dep).with_ensure('present') }
+      end
+
+    end
+    describe "jenkins_job_builder class without any parameters on a 'RedHat' OS" do
+      let(:params) {{ }}
+      let(:facts) {{
+        :osfamily => 'RedHat',
+      }}
+
+      ['python', 'python-pip', 'pyyaml', 'python-argparse'].each do |dep|
+        it { should contain_package(dep).with_ensure('present') }
+      end
+
     end
   end
 


### PR DESCRIPTION
The difference between the listed packages for 'Debian' and 'Redhat' was causing a test failure, this PR fixes that