### PR TITLE
Allow installation of jenkins_job_builder from git

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
+    vcsrepo: "https://github.com/puppetlabs/puppetlabs-vcsrepo.git"
   symlinks:
     jenkins_job_builder: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,13 +40,17 @@
 # }
 #
 class jenkins_job_builder(
-  $version = $jenkins_job_builder::params::version,
-  $jobs = $jenkins_job_builder::params::jobs,
-  $user = $jenkins_job_builder::params::user,
-  $password = $jenkins_job_builder::params::password,
-  $hipchat_token = $jenkins_job_builder::params::hipchat_token,
-  $jenkins_url = $jenkins_job_builder::params::jenkins_url,
-  $service = 'jenkins'
+  $version          = $jenkins_job_builder::params::version,
+  $jobs             = $jenkins_job_builder::params::jobs,
+  $user             = $jenkins_job_builder::params::user,
+  $password         = $jenkins_job_builder::params::password,
+  $hipchat_token    = $jenkins_job_builder::params::hipchat_token,
+  $jenkins_url      = $jenkins_job_builder::params::jenkins_url,
+  $service          = 'jenkins',
+  $install_from_git = $jenkins_job_builder::params::install_from_git,
+  $git_revision     = $jenkins_job_builder::params::git_revision,
+  $git_url          = $jenkins_job_builder::params::git_url,
+
 ) inherits jenkins_job_builder::params {
 
   validate_re($::osfamily,'RedHat|Debian',"${::osfamily} not supported")
@@ -56,6 +60,9 @@ class jenkins_job_builder(
   validate_string($hipchat_token)
   validate_string($jenkins_url)
   validate_string($version)
+  validate_string($git_revision)
+  validate_string($git_url)
+  validate_bool($install_from_git)
 
   class {'jenkins_job_builder::install': } ->
   class {'jenkins_job_builder::config': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,10 @@
 # It installs the pip package and all required dependencies
 #
 class jenkins_job_builder::install(
-  $version = $jenkins_job_builder::version
+  $version          = $jenkins_job_builder::version,
+  $install_from_git = $jenkins_job_builder::install_from_git,
+  $git_url          = $jenkins_job_builder::git_url,
+  $git_revision     = $jenkins_job_builder::git_revision,
 ) {
 
   if $caller_module_name != $module_name {
@@ -18,8 +21,28 @@ class jenkins_job_builder::install(
   ensure_resource('package', $jenkins_job_builder::params::python_packages, { 'ensure' => 'present' })
   ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => 'Package[python]'})
 
-  package { 'jenkins-job-builder':
-    ensure   => $version,
-    provider => 'pip'
+  if $install_from_git {
+
+    vcsrepo { '/opt/jenkins_job_builder':
+      ensure   => latest,
+      provider => git,
+      revision => $git_revision,
+      source   => $git_url,
+    }
+
+    exec { 'install_jenkins_job_builder':
+      command     => 'pip install /opt/jenkins_job_builder',
+      path        => '/usr/local/bin:/usr/bin:/bin/',
+      refreshonly => true,
+      subscribe   => Vcsrepo['/opt/jenkins_job_builder'],
+    }
+
+  } else {
+
+    package { 'jenkins-job-builder':
+      ensure   => $version,
+      provider => 'pip'
+    }
+
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,9 @@ class jenkins_job_builder::params {
   $jenkins_url = 'http://localhost:8080'
   $version = 'latest'
   $service = 'jenkins'
+  $install_from_git = false
+  $git_revision     = 'master'
+  $git_url          = 'https://git.openstack.org/openstack-infra/jenkins-job-builder'
 
   case $::osfamily {
     'RedHat', 'Amazon': {

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -64,6 +64,23 @@ describe 'jenkins_job_builder' do
     end
   end
 
+  context 'install from git' do
+    describe 'jenkins_job_builder installed from git' do
+      let(:params) {{
+        :install_from_git => true,
+      }}
+      let(:facts) {{
+        :osfamily => 'Debian',
+      }}
+
+      it { should contain_vcsrepo('/opt/jenkins_job_builder').with(
+        'ensure'   => 'latest',
+        'provider' => 'git',
+      )}
+
+    end
+  end
+
   context 'unsupported operating system' do
     describe 'jenkins_job_builder class without any parameters on Solaris/Nexenta' do
       let(:facts) {{
@@ -106,4 +123,5 @@ describe 'jenkins_job_builder' do
       )}
     end
   end
+
 end

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -67,15 +67,15 @@ describe 'jenkins_job_builder' do
   context 'install from git' do
     describe 'jenkins_job_builder installed from git' do
       let(:params) {{
-        :install_from_git => true,
+        :install_from_git => true
       }}
       let(:facts) {{
-        :osfamily => 'Debian',
+        :osfamily => 'Debian'
       }}
 
       it { should contain_vcsrepo('/opt/jenkins_job_builder').with(
         'ensure'   => 'latest',
-        'provider' => 'git',
+        'provider' => 'git'
       )}
 
     end
@@ -85,7 +85,7 @@ describe 'jenkins_job_builder' do
     describe 'jenkins_job_builder class without any parameters on Solaris/Nexenta' do
       let(:facts) {{
         :osfamily        => 'Solaris',
-        :operatingsystem => 'Nexenta',
+        :operatingsystem => 'Nexenta'
       }}
 
       it { expect { should contain_package('jenkins_job_builder') }.to raise_error(Puppet::Error, /Nexenta not supported/) }


### PR DESCRIPTION
This PR addresses #15

In particular, this was added to access the [job-dsl](http://ci.openstack.org/jenkins-job-builder/builders.html#builders.dsl) feature that is not available in the current release on PyPi