### PR TITLE
Job creation retry implementation

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -53,6 +53,8 @@ define jenkins_job_builder::job (
   $delay = 0,
   $service_name = 'jenkins',
   $job_yaml = '',
+  $tries = '5',
+  $try_sleep = '15',
 ) {
 
   if $config != {} {
@@ -69,6 +71,8 @@ define jenkins_job_builder::job (
   exec { "manage jenkins job - ${name}":
     command     => "/bin/sleep ${delay} && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-${name}.yaml",
     refreshonly => true,
+    tries       => $tries,
+    try_sleep   => $try_sleep,
     require     => Service[$service_name]
   }
 

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -13,7 +13,9 @@ describe 'jenkins_job_builder::job', :type => :define do
         it { should contain_exec('manage jenkins job - test').with(
           'command' => '/bin/sleep 0 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
           'refreshonly' => 'true',
-          'require' => 'Service[jenkins]'
+          'require' => 'Service[jenkins]',
+          'tries' => '5',
+          'try_sleep' => '15',
         )}
       end
     end
@@ -28,6 +30,20 @@ describe 'jenkins_job_builder::job', :type => :define do
 
       it { should contain_exec('manage jenkins job - test').with(
         'command' => '/bin/sleep 5 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml'
+      )}
+    end
+
+    describe 'with retry mechanism' do
+      let(:title) { 'test' }
+      let(:params) {{
+        'tries' => '10',
+        'try_sleep' => '45',
+      }}
+
+      it { should contain_exec('manage jenkins job - test').with(
+        'command' => '/bin/sleep 0 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
+        'tries' => '10',
+        'try_sleep' => '45',
       )}
     end
 


### PR DESCRIPTION
This adds `tries` and `try_sleep` params to the job creation define, in order to provide the retry mechanism outlined in #21 